### PR TITLE
Add Docker workflow support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM python:onbuild
+
+ENTRYPOINT [ "./mgcli.py" ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 docopt
+jinja2
+pandas
 requests


### PR DESCRIPTION
(Depends on #1 to build)

Add Dockerfile to enable image building.
Using the official Python image, latest 'onbuild' tag. More info at https://hub.docker.com/_/python/

The 'onbuild' tag just automatically triggers adding files, setting working dir and running standard build instructions.

Build:
```
$ docker build -t mgcli .
```

Run:
```
$ docker run --rm -it -e ENV_VAR1=value1 mgcli [options...]
```
Use Docker's `-v` switch to mount files from the host inside the container, if needed.
Using `--rm` makes the container to be deleted after stopping. Should stop by `CTRL+C`'ing it, anyway.