### PR TITLE
Minor docs improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Rebuild the image:
 docker build -t {image-name} .
 ```
 
-There is now auto-build `hupili/mgcli` on dockerhub, so the `master` of this repo will be reflected in `hupili/mgcli:latest` automatically. The tags `/release-.*/` will also trigger auto-builds on dockerhub.
+There is now an [Automated Build](https://docs.docker.com/docker-hub/builds/) on Docker Hub at [hupili/mgcli](https://hub.docker.com/r/hupili/mgcli/), so the `master` branch of this repo will be reflected in `hupili/mgcli:latest` automatically. The tags `/release-.*/` will also trigger corresponding image tags auto-builds on Docker Hub.
 
 ## License
 

--- a/mgcli.py
+++ b/mgcli.py
@@ -36,8 +36,8 @@ Options:
 
 
 # Use ~/.mgcli/ dir as a workaround for docker mounting issue.
-# Docker by default mount path as directory. Upon the first 
-# execution, there is no config file and mounting dir allows 
+# Docker by default mount path as directory. Upon the first
+# execution, there is no config file and mounting dir allows
 # the mgcli script to create it inside container.
 FN_CONFIG = path.expanduser('~/.mgcli/mgclirc')
 DIR_CONFIG = path.dirname(FN_CONFIG)


### PR DESCRIPTION
Clean, format and add links to docs.
Nitpick: trailing whitespace on code comments.

Followup to #2 & #3.
Also, I recommend adding ```--rm -it``` switches to ```docker run``` command in the docs if no files are created outside mounts which can be lost, just to keep user's hosts clean and tidy of finished containers on each command run. 